### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools", "wheel", "numpy", "pandas", "astropy", "requests", "scipy"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will help with installing gPhoton on a fresh system, avoiding the need for preinstalled numpy.